### PR TITLE
Added flux error column to return table

### DIFF
--- a/glowing_waffles/photometry.py
+++ b/glowing_waffles/photometry.py
@@ -7,7 +7,7 @@ from .coordinates import convert_pixel_wcs
 __all__ = ['photutils_stellar_photometry']
 
 def photutils_stellar_photometry(ccd_image, sources, aperture_radius, inner_annulus
-                                 outer_annulus, gain):
+                                 outer_annulus, gain, N_R, N_dark_pp):
     """
     Perform aperture photometry on an image, with a few options for estimating
     the local background from an annulus around the aperture.

--- a/glowing_waffles/photometry.py
+++ b/glowing_waffles/photometry.py
@@ -7,7 +7,7 @@ from .coordinates import convert_pixel_wcs
 __all__ = ['photutils_stellar_photometry']
 
 def photutils_stellar_photometry(ccd_image, sources, aperture_radius, inner_annulus
-                                 outer_annulus, gain, N_R, N_dark_pp):
+                                 outer_annulus, gain=1.0, N_R=0, N_dark_pp=0):
     """
     Perform aperture photometry on an image, with a few options for estimating
     the local background from an annulus around the aperture.

--- a/glowing_waffles/photometry.py
+++ b/glowing_waffles/photometry.py
@@ -10,7 +10,7 @@ from .coordinates import convert_pixel_wcs
 __all__ = ['photutils_stellar_photometry']
 
 def photutils_stellar_photometry(ccd_image, sources, aperture_radius, inner_annulus
-                                 outer_annulus):
+                                 outer_annulus, gain):
     """
     Perform aperture photometry on an image, with a few options for estimating
     the local background from an annulus around the aperture.
@@ -32,6 +32,15 @@ def photutils_stellar_photometry(ccd_image, sources, aperture_radius, inner_annu
 
     outer_annulus : float
         Outer radius of the annulus in pixels.
+
+    gain : float
+        Gain of the CCD. In units of electrons per DN.
+
+    N_R : float
+        Read noise of the CCD in electrons per pixel.
+
+    N_dark_pp : float
+        Number of dark counts per pixel.
 
     Returns
     -------
@@ -75,14 +84,9 @@ def photutils_stellar_photometry(ccd_image, sources, aperture_radius, inner_annu
     phot_table['RA_center'] = ra
     phot_table['Dec_center'] = dec
 
+    # Obtain flux error and add column to return table
+    noise = np.sqrt(gain*net_flux + n_pix_ap*(1 + (n_pix_ap/n_pix_ann))
+			 *(gain*(bkgd_pp + N_dark_pp) + (N_R**2)))
+    phot_table['aperture_sum_err'] = np.ones(len(phot_table['aperture_sum'])) * noise
 
-    # Return a table that includes at least:
-    #   + ra, dec of center
-    #   + x, y of center
-    #   + flux
-    #   + sky background per pixel
-    #   + aperture radius used
-    #   + annulus radii used
-    #   + net flux
-    #   + flux error
     return phot_table

--- a/glowing_waffles/photometry.py
+++ b/glowing_waffles/photometry.py
@@ -1,8 +1,5 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
-from astropy import units as u
-from astropy.stats import mad_std
-from astropy.io import fits
 from astropy.table import Table, join
 from photutils import aperture_photometry, CircularAperture, CircularAnnulus
 from .coordinates import convert_pixel_wcs
@@ -87,6 +84,6 @@ def photutils_stellar_photometry(ccd_image, sources, aperture_radius, inner_annu
     # Obtain flux error and add column to return table
     noise = np.sqrt(gain*net_flux + n_pix_ap*(1 + (n_pix_ap/n_pix_ann))
 			 *(gain*(bkgd_pp + N_dark_pp) + (N_R**2)))
-    phot_table['aperture_sum_err'] = np.ones(len(phot_table['aperture_sum'])) * noise
+    phot_table['aperture_sum_err'] = noise
 
     return phot_table


### PR DESCRIPTION
Added a flux error column to the return table of photometry function. I wasn't sure whether this should be calculated on a per aperture basis or as a single value. I did 
    phot_table['aperture_sum_err'] = np.ones(len(phot_table['aperture_sum'])) \* noise

making the flux_error a mono-value column. 
Also, for the documentation I mostly pasted from the docstring for astropy's signal_to_noise_oir_ccd, so if anything there needs to be changed let me know.
